### PR TITLE
docs: remove legacy onlyUnowned references

### DIFF
--- a/docs/P1.1_IMPLEMENTATION_GUIDE.md
+++ b/docs/P1.1_IMPLEMENTATION_GUIDE.md
@@ -91,12 +91,12 @@ def fetch_playlist_tracks(playlist_id_or_url: str) -> Dict[str, Any]:
 // Before
 const displayedTracks = useMemo(() => {
   let filtered = currentResult.tracks;
-  if (onlyUnowned) {
+  if (categoryFilter === 'toBuy') {
     filtered = filtered.filter((t) => t.owned === false);
   }
   // ... filtering/sorting logic
   return filtered;
-}, [currentResult, onlyUnowned, searchQuery, sortKey]);
+}, [currentResult, categoryFilter, searchQuery, sortKey]);
 
 // TrackRow を memo化
 const TrackRowMemo = React.memo(TrackRow);


### PR DESCRIPTION
What
- Remove docs-only `onlyUnowned` references (align docs with To Buy tab)

Risk
- None (docs only)
