### PR TITLE
fix(ci): install pytest in CI + allow manual dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI (backend)
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [main]
@@ -38,6 +39,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
       - name: Run tests
         env:
           # dummy only


### PR DESCRIPTION
Gate-0 follow-up: mainのCI(backend)でpytestが未導入で落ちていたため修正。workflow_dispatchを追加してmainで手動実行できるようにする。