### PR TITLE
fix(ci): set SPOTIFY_CLIENT_SECRET dummy for tests (allowlisted)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           # dummy only
           SPOTIFY_CLIENT_ID: "dummy"
-          SPOTIFY_CLIENT_CRED_DUMMY: "dummy"
+          SPOTIFY_CLIENT_SECRET: "dummy"  # pragma: allowlist secret
           ALLOWED_ORIGINS: "https://example.invalid"
           CORS_ALLOW_CREDENTIALS: "true"
         run: |


### PR DESCRIPTION
CIのpytestが SPOTIFY_CLIENT_SECRET 未設定で落ちていたため、dummyを設定。detect-secrets は pragma allowlist で誤検知回避。