### PR TITLE
Add Spotify BPM and key enrichment

### DIFF
--- a/app.py
+++ b/app.py
@@ -144,6 +144,11 @@ class TrackModel(BaseModel):
     spotify_url: Optional[str] = None
     apple_url: Optional[str] = None
     links: Optional[StoreLinksModel] = None
+    bpm: Optional[int] = None
+    key: Optional[str] = None
+    tempo: Optional[float] = None
+    spotifyKey: Optional[int] = None
+    spotifyMode: Optional[int] = None
     owned: Optional[bool] = None
     owned_reason: Optional[str] = None
     track_key_primary: Optional[str] = (

--- a/core.py
+++ b/core.py
@@ -97,6 +97,22 @@ from spotipy.exceptions import SpotifyException
 # Configure logger for this module
 logger = logging.getLogger(__name__)
 
+SPOTIFY_AUDIO_FEATURES_BATCH_SIZE = 100
+SPOTIFY_KEY_LABELS = {
+    0: "C",
+    1: "C#/Db",
+    2: "D",
+    3: "D#/Eb",
+    4: "E",
+    5: "F",
+    6: "F#/Gb",
+    7: "G",
+    8: "G#/Ab",
+    9: "A",
+    10: "A#/Bb",
+    11: "B",
+}
+
 
 class AppleFetchError(Exception):
     """Custom error to carry Apple-specific meta for diagnostics."""
@@ -330,6 +346,80 @@ def build_store_links(
     }
 
 
+def format_spotify_key(key: int | None, mode: int | None) -> str | None:
+    """Convert Spotify audio-features key/mode to a DJ-friendly display string."""
+    if key is None or mode is None:
+        return None
+    if key not in SPOTIFY_KEY_LABELS or mode not in (0, 1):
+        return None
+
+    label = SPOTIFY_KEY_LABELS[key]
+    if mode == 1:
+        return label
+
+    if "/" in label:
+        return "/".join(f"{part}m" for part in label.split("/"))
+    return f"{label}m"
+
+
+def _chunked(values: List[str], size: int) -> List[List[str]]:
+    return [values[i : i + size] for i in range(0, len(values), size)]
+
+
+def _build_audio_features_map(
+    sp: spotipy.Spotify,
+    track_ids: List[str],
+) -> Dict[str, Dict[str, Any]]:
+    """Fetch Spotify audio features in batches and index by track ID."""
+    features_by_id: Dict[str, Dict[str, Any]] = {}
+
+    for batch in _chunked(track_ids, SPOTIFY_AUDIO_FEATURES_BATCH_SIZE):
+        features = sp.audio_features(batch) or []
+        for feature in features:
+            if not feature:
+                continue
+            track_id = feature.get("id")
+            if isinstance(track_id, str) and track_id:
+                features_by_id[track_id] = feature
+
+    return features_by_id
+
+
+def _enrich_items_with_audio_features(
+    sp: spotipy.Spotify,
+    items: List[Dict[str, Any]],
+) -> None:
+    """Best-effort audio-features enrichment for Spotify playlist items."""
+    track_ids: List[str] = []
+    seen: set[str] = set()
+
+    for item in items:
+        track = item.get("track") or {}
+        track_id = track.get("id")
+        if isinstance(track_id, str) and track_id and track_id not in seen:
+            seen.add(track_id)
+            track_ids.append(track_id)
+
+    if not track_ids:
+        return
+
+    try:
+        features_by_id = _build_audio_features_map(sp, track_ids)
+    except Exception as exc:
+        logger.warning("[Spotify] audio features enrichment failed: %s", exc)
+        return
+
+    for item in items:
+        track = item.get("track") or {}
+        track_id = track.get("id")
+        if not isinstance(track_id, str) or not track_id:
+            continue
+        feature = features_by_id.get(track_id)
+        if feature:
+            track["audio_features"] = feature
+            item["track"] = track
+
+
 # =========================
 # プレイリスト取得
 # =========================
@@ -521,6 +611,8 @@ def fetch_playlist_tracks(url_or_id: str) -> Dict[str, Any]:
         )
         raise RuntimeError(prefix + hint)
 
+    _enrich_items_with_audio_features(sp, items)
+
     return {
         "playlist": playlist,
         "items": items,
@@ -652,6 +744,11 @@ def playlist_result_to_dict(raw: Dict[str, Any]) -> Dict[str, Any]:
         spotify_url = track.get("external_urls", {}).get("spotify", "")
         apple_url = track.get("external_urls", {}).get("apple", "")
         isrc = (track.get("external_ids") or {}).get("isrc")  # ISRC from Spotify
+        audio_features = track.get("audio_features") or {}
+        spotify_key = audio_features.get("key")
+        spotify_mode = audio_features.get("mode")
+        tempo = audio_features.get("tempo")
+        bpm = round(tempo) if isinstance(tempo, (int, float)) else None
 
         links = build_store_links(title, artist_name, album_name, isrc=isrc)
 
@@ -678,6 +775,13 @@ def playlist_result_to_dict(raw: Dict[str, Any]) -> Dict[str, Any]:
                 "spotify_url": spotify_url,
                 "apple_url": apple_url,
                 "links": links,
+                "bpm": bpm,
+                "key": format_spotify_key(spotify_key, spotify_mode),
+                "tempo": tempo if isinstance(tempo, (int, float)) else None,
+                "spotifyKey": spotify_key if isinstance(spotify_key, int) else None,
+                "spotifyMode": (
+                    spotify_mode if isinstance(spotify_mode, int) else None
+                ),
                 "track_key_primary": final_primary,
                 "track_key_fallback": track_key_fallback,
                 "track_key_primary_type": track_key_primary_type,  # UI hint: "isrc" → confident, "norm" → ambiguous

--- a/tests/test_spotify_audio_features.py
+++ b/tests/test_spotify_audio_features.py
@@ -1,0 +1,114 @@
+import unittest
+from unittest.mock import Mock
+
+from core import (
+    _enrich_items_with_audio_features,
+    format_spotify_key,
+    playlist_result_to_dict,
+)
+
+
+class SpotifyAudioFeaturesTests(unittest.TestCase):
+    def test_format_spotify_key_major_and_minor(self):
+        self.assertEqual(format_spotify_key(0, 1), "C")
+        self.assertEqual(format_spotify_key(0, 0), "Cm")
+        self.assertEqual(format_spotify_key(1, 1), "C#/Db")
+        self.assertEqual(format_spotify_key(1, 0), "C#m/Dbm")
+
+    def test_format_spotify_key_invalid_returns_none(self):
+        self.assertIsNone(format_spotify_key(-1, 1))
+        self.assertIsNone(format_spotify_key(0, None))
+        self.assertIsNone(format_spotify_key(None, 1))
+        self.assertIsNone(format_spotify_key(12, 1))
+        self.assertIsNone(format_spotify_key(5, 3))
+
+    def test_playlist_result_to_dict_emits_audio_feature_fields(self):
+        raw = {
+            "playlist": {
+                "id": "playlist-1",
+                "name": "Test Playlist",
+                "external_urls": {
+                    "spotify": "https://open.spotify.com/playlist/playlist-1"
+                },
+            },
+            "items": [
+                {
+                    "track": {
+                        "id": "track-1",
+                        "name": "Track A",
+                        "artists": [{"name": "Artist A"}],
+                        "album": {"name": "Album A"},
+                        "external_urls": {
+                            "spotify": "https://open.spotify.com/track/track-1"
+                        },
+                        "external_ids": {"isrc": "ISRC123"},
+                        "audio_features": {
+                            "id": "track-1",
+                            "tempo": 127.6,
+                            "key": 1,
+                            "mode": 0,
+                        },
+                    }
+                },
+                {
+                    "track": {
+                        "id": "track-2",
+                        "name": "Track B",
+                        "artists": [{"name": "Artist B"}],
+                        "album": {"name": "Album B"},
+                        "external_urls": {
+                            "spotify": "https://open.spotify.com/track/track-2"
+                        },
+                        "external_ids": {},
+                    }
+                },
+            ],
+        }
+
+        result = playlist_result_to_dict(raw)
+
+        self.assertEqual(result["tracks"][0]["tempo"], 127.6)
+        self.assertEqual(result["tracks"][0]["bpm"], 128)
+        self.assertEqual(result["tracks"][0]["spotifyKey"], 1)
+        self.assertEqual(result["tracks"][0]["spotifyMode"], 0)
+        self.assertEqual(result["tracks"][0]["key"], "C#m/Dbm")
+
+        self.assertIsNone(result["tracks"][1]["tempo"])
+        self.assertIsNone(result["tracks"][1]["bpm"])
+        self.assertIsNone(result["tracks"][1]["spotifyKey"])
+        self.assertIsNone(result["tracks"][1]["spotifyMode"])
+        self.assertIsNone(result["tracks"][1]["key"])
+
+    def test_enrich_items_with_audio_features_is_best_effort(self):
+        sp = Mock()
+        sp.audio_features.side_effect = RuntimeError("spotify down")
+        items = [
+            {"track": {"id": "track-1", "name": "Track A"}},
+            {"track": {"id": "track-2", "name": "Track B"}},
+        ]
+
+        _enrich_items_with_audio_features(sp, items)
+
+        self.assertNotIn("audio_features", items[0]["track"])
+        self.assertNotIn("audio_features", items[1]["track"])
+
+    def test_enrich_items_with_audio_features_maps_batches_back_to_tracks(self):
+        sp = Mock()
+        sp.audio_features.return_value = [
+            {"id": "track-1", "tempo": 128.2, "key": 0, "mode": 1},
+            None,
+        ]
+        items = [
+            {"track": {"id": "track-1", "name": "Track A"}},
+            {"track": {"id": "track-2", "name": "Track B"}},
+        ]
+
+        _enrich_items_with_audio_features(sp, items)
+
+        sp.audio_features.assert_called_once_with(["track-1", "track-2"])
+        self.assertEqual(items[0]["track"]["audio_features"]["tempo"], 128.2)
+        self.assertNotIn("audio_features", items[1]["track"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds best-effort Spotify audio-features enrichment for DJ-facing BPM and key display metadata.

Scope:
- backend only
- no frontend changes
- no Rekordbox matching changes
- no ownership logic changes

Changes:
- fetches Spotify audio features in batches after playlist track fetch
- maps audio features back onto playlist items before row construction
- emits optional per-row fields:
  - tempo
  - bpm
  - spotifyKey
  - spotifyMode
  - key
- adds Spotify key/mode display conversion
- keeps enrichment best-effort so playlist analysis still succeeds if audio features fail

Validation:
- python -m unittest tests.test_spotify_audio_features -v
- python -m unittest tests.test_matcher tests.test_normalizer -v
- pre-commit hooks: ruff, ruff-format, conflict checks, whitespace checks