### PR TITLE
Restore Rekordbox ownership matching fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -587,7 +587,7 @@ async def playlist_with_rekordbox(body: PlaylistWithRekordboxBody, request: Requ
         playlist_data,
         body.rekordbox_xml_path,
     )
-    return JSONResponse(content=_sanitize_for_json(playlist_with_owned))
+    return playlist_with_owned
 
 
 @app.post("/api/match-snapshot-with-xml")
@@ -894,7 +894,7 @@ async def playlist_with_rekordbox_upload(
         f"cache_hit={'true' if 'cache_hit' in locals() and cache_hit else 'false'} cache_ttl_s={PLAYLIST_CACHE_TTL_S} cache_size={len(PLAYLIST_CACHE)} refresh={'1' if (refresh == 1) else '0'} "
         f"fetch_ms={fetch_ms:.1f} xml_ms={xml_ms:.1f} total_ms={total_ms:.1f} tracks={tracks_count}"
     )
-    return JSONResponse(content=_sanitize_for_json(playlist_with_owned))
+    return playlist_with_owned
 
 
 # =========================

--- a/lib/rekordbox/normalizer.py
+++ b/lib/rekordbox/normalizer.py
@@ -37,6 +37,7 @@ def normalize_title_base(title: str) -> str:
     """
     タイトルの基本正規化:
     - 小文字化
+    - アンダースコア区切りをスペースとして扱う
     - () / [] 内の表記を削る (MIX名やレーベルなど)
     - feat. / ft. / featuring 以降を削る
     - 末尾の " - original mix" 系を削る
@@ -44,6 +45,7 @@ def normalize_title_base(title: str) -> str:
     - 区切り文字 | をエスケープ（track_key_fallback用）
     """
     s = (title or "").lower().strip()
+    s = s.replace("_", " ")
 
     # 括弧の中身を全部落とす（位置に関係なく）
     s = re.sub(r"\([^)]*\)", "", s)

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -10,6 +10,8 @@ def _write_xml(tmp_path: Path) -> Path:
   <COLLECTION>
     <TRACK Name="Song A" Artist="Artist A" Album="Album A" ISRC="ISRC123" />
     <TRACK Name="Bright Lights" Artist="Artist B" Album="Album B" />
+    <TRACK Name="Goodums_-_Sammy_Virji_Remix" Artist="Sammy Virji" Album="Album C" />
+    <TRACK Name="Shapes_(Oh_Will)_-_Oppidan_Remix" Artist="Oppidan" Album="Album D" />
   </COLLECTION>
 </DJ_PLAYLISTS>
 """
@@ -56,6 +58,33 @@ class MatcherTests(unittest.TestCase):
         track = result["tracks"][0]
         self.assertTrue(track["owned"])
         self.assertEqual(track["owned_reason"], "fuzzy")
+
+    def test_mark_owned_matches_titles_with_underscore_separators(self):
+        tmp_dir = Path(self._get_tmp_dir())
+        xml_path = _write_xml(tmp_dir)
+        playlist = {
+            "tracks": [
+                {
+                    "title": "Goodums - Sammy Virji Remix",
+                    "artist": "Sammy Virji",
+                    "album": "Album C",
+                    "isrc": None,
+                },
+                {
+                    "title": "Shapes (Oh Will) - Oppidan Remix",
+                    "artist": "Oppidan",
+                    "album": "Album D",
+                    "isrc": None,
+                },
+            ]
+        }
+
+        result = mark_owned_tracks(playlist, xml_path)
+
+        self.assertTrue(result["tracks"][0]["owned"])
+        self.assertEqual(result["tracks"][0]["owned_reason"], "exact")
+        self.assertTrue(result["tracks"][1]["owned"])
+        self.assertEqual(result["tracks"][1]["owned_reason"], "exact")
 
     def _get_tmp_dir(self) -> str:
         # unittest doesn't provide tmp_path fixture; use mkdtemp

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -14,6 +14,14 @@ class NormalizeTests(unittest.TestCase):
     def test_normalize_title_base_removes_parens_and_mix(self):
         self.assertEqual(normalize_title_base("My Song (Original Mix)"), "my song")
         self.assertEqual(normalize_title_base("Track [Deluxe] - Radio Edit"), "track")
+        self.assertEqual(
+            normalize_title_base("Goodums_-_Sammy_Virji_Remix"),
+            "goodums - sammy virji remix",
+        )
+        self.assertEqual(
+            normalize_title_base("Shapes_(Oh_Will)_-_Oppidan_Remix"),
+            "shapes - oppidan remix",
+        )
 
     def test_normalize_album_simplifies_spacing(self):
         self.assertEqual(normalize_album("Album Name (Deluxe Edition)"), "album name")

--- a/tests/test_upload_contract.py
+++ b/tests/test_upload_contract.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import app as app_module
+
+
+client = TestClient(app_module.app)
+
+
+async def _fake_fetch_playlist_tracks_generic(source, url, **kwargs):
+    return {"source": source, "url": url}
+
+
+def _fake_playlist_result_to_dict(_result):
+    return {
+        "playlist_id": "playlist-1",
+        "playlist_name": "Test Playlist",
+        "playlist_url": "https://example.com/playlist/1",
+        "tracks": [
+            {
+                "title": "Track A",
+                "artist": "Artist A",
+                "album": "Album A",
+                "isrc": "ISRC123",
+            },
+            {
+                "title": "Track B",
+                "artist": "Artist B",
+                "album": "Album B",
+                "isrc": None,
+            },
+        ],
+    }
+
+
+def _fake_apply_rekordbox_owned_flags(playlist_data, _library_xml_path):
+    playlist_data["tracks"][0]["owned"] = True
+    playlist_data["tracks"][0]["owned_reason"] = "isrc"
+    playlist_data["tracks"][1]["owned"] = False
+    playlist_data["tracks"][1]["owned_reason"] = None
+    return playlist_data
+
+
+class UploadContractTests(unittest.TestCase):
+    @patch.object(
+        app_module,
+        "_apply_rekordbox_owned_flags",
+        side_effect=_fake_apply_rekordbox_owned_flags,
+    )
+    @patch.object(
+        app_module,
+        "playlist_result_to_dict",
+        side_effect=_fake_playlist_result_to_dict,
+    )
+    @patch.object(
+        app_module,
+        "fetch_playlist_tracks_generic",
+        side_effect=_fake_fetch_playlist_tracks_generic,
+    )
+    def test_playlist_with_rekordbox_upload_uses_json_boolean_and_null_types(
+        self,
+        _mock_fetch,
+        _mock_playlist_to_dict,
+        _mock_apply_flags,
+    ):
+        response = client.post(
+            "/api/playlist-with-rekordbox-upload",
+            data={"url": "https://open.spotify.com/playlist/abc", "source": "spotify"},
+            files={"file": ("library.xml", b"<DJ_PLAYLISTS />", "text/xml")},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+
+        self.assertIs(payload["tracks"][0]["owned"], True)
+        self.assertEqual(payload["tracks"][0]["owned_reason"], "isrc")
+        self.assertIs(payload["tracks"][1]["owned"], False)
+        self.assertIsNone(payload["tracks"][1]["owned_reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Restores ownership matching fixes that are required for Rekordbox XML matching.

Changes:
- restores normalized upload response contract for Rekordbox XML results
- restores underscore-separated Rekordbox title normalization for ownership matching

Reason:
- playlists with many owned tracks can currently appear as entirely not owned
- the ownership workflow depends on these matching fixes

Validation:
- python -m unittest tests.test_matcher tests.test_normalizer -v
- git diff --check