### PR TITLE
Add Render health route

### DIFF
--- a/app.py
+++ b/app.py
@@ -359,6 +359,11 @@ def root() -> Dict[str, Any]:
     return {"ok": True, "status": "ok"}
 
 
+@app.get("/health", include_in_schema=False)
+def render_health() -> Dict[str, Any]:
+    return health()
+
+
 # =========================
 # Core helpers
 # =========================

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,36 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+import app as app_module
+
+
+client = TestClient(app_module.app)
+
+
+class HealthRouteTests(unittest.TestCase):
+    def test_render_health_route_returns_ok(self):
+        response = client.get("/health")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIs(payload["ok"], True)
+        self.assertEqual(payload["status"], "ok")
+
+    def test_api_health_route_still_returns_ok(self):
+        response = client.get("/api/health")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+
+    def test_root_route_still_returns_ok(self):
+        response = client.get("/")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIs(payload["ok"], True)
+        self.assertEqual(payload["status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a /health endpoint for Render health checks.

Changes:
- Add GET /health with include_in_schema=False
- Reuse the existing health() helper
- Add regression tests for /health, /api/health, and /

Validation:
- python -m unittest tests.test_health -v
- python -m unittest tests.test_upload_contract -v
- python -m unittest discover -s tests -p "test_*.py" -v
- git diff --check