### PR TITLE
Reduce Rekordbox matcher false negatives

### DIFF
--- a/lib/rekordbox/matcher.py
+++ b/lib/rekordbox/matcher.py
@@ -17,6 +17,7 @@ from lib.rekordbox.normalizer import (
     normalize_artist,
     normalize_title_base,
     normalize_album,
+    generate_title_artist_pairs,
 )
 from lib.rekordbox.parser import load_rekordbox_library_xml
 
@@ -77,9 +78,10 @@ def mark_owned_tracks(
 
         # 2) タイトル＋アーティスト（正規化）の組み合わせ一致
         if not owned and title_norm and artist_norm:
-            key = (title_norm, artist_norm)
-            matches = lib.by_title_artist.get(key, [])
-            if matches:
+            for key in generate_title_artist_pairs(t["title"], t["artist"]):
+                matches = lib.by_title_artist.get(key, [])
+                if not matches:
+                    continue
                 rb_track = matches[0]  # 最初のマッチを使用
                 owned = True
                 owned_detail = {
@@ -89,6 +91,7 @@ def mark_owned_tracks(
                     "matched_artist": rb_track.artist,
                     "rb_track": rb_track,
                 }
+                break
 
         # 3) タイトル＋アルバム（正規化）の組み合わせ一致
         #    → アーティスト名がカタカナ／別表記でも拾えるようにする

--- a/lib/rekordbox/normalizer.py
+++ b/lib/rekordbox/normalizer.py
@@ -7,6 +7,14 @@ from __future__ import annotations
 import re
 from typing import List, Tuple
 
+_TRAILING_TEMPO_RE = re.compile(
+    r"\s+(?:\d{2,3}(?:\.\d+)?|\d{2,3}\s*-\s*\d{2,3}(?:\.\d+)?)\s*$"
+)
+
+
+def _normalize_dash_chars(text: str) -> str:
+    return text.replace("—", "-").replace("–", "-").replace("−", "-").replace("―", "-")
+
 
 def normalize_artist(name: str) -> str:
     """
@@ -17,7 +25,7 @@ def normalize_artist(name: str) -> str:
     - 余分なスペースを詰める
     - 区切り文字 | をエスケープ（track_key_fallback用）
     """
-    s = (name or "").lower().strip()
+    s = _normalize_dash_chars((name or "").lower().strip())
 
     # 代表アーティストだけ残す
     for sep in [",", "&", " and "]:
@@ -44,8 +52,14 @@ def normalize_title_base(title: str) -> str:
     - 余分なスペースを詰める
     - 区切り文字 | をエスケープ（track_key_fallback用）
     """
-    s = (title or "").lower().strip()
+    s = _normalize_dash_chars((title or "").lower().strip())
     s = s.replace("_", " ")
+
+    # 末尾の BPM / テンポ表記を削る（例: "169.98", "160-145"）
+    s = _TRAILING_TEMPO_RE.sub("", s)
+
+    # Rekordbox で末尾につきがちな "Master" は非意味情報として扱う
+    s = re.sub(r"\s+master$", "", s)
 
     # 括弧の中身を全部落とす（位置に関係なく）
     s = re.sub(r"\([^)]*\)", "", s)
@@ -54,9 +68,9 @@ def normalize_title_base(title: str) -> str:
     # タイトル内の feat... を削る
     s = re.sub(r"\s+(feat\.|ft\.|featuring)\s+.*$", "", s)
 
-    # 末尾の " - original mix / extended mix / edit / remix..." を削る
+    # 末尾の " - original mix / X remix / extended / edit ..." を削る
     s = re.sub(
-        r"\s*-\s*(original mix|extended mix|radio edit|club mix|dub mix|dub|vip|edit|remix.*|mix)$",
+        r"\s*-\s*(?:.*\b)?(original mix|extended mix|extended|radio edit|club mix|dub mix|dub|vip|edit|remix|mix)\b.*$",
         "",
         s,
     )
@@ -75,7 +89,7 @@ def normalize_album(album: str) -> str:
     - 余分なスペースを詰める
     - 区切り文字 | をエスケープ（track_key_fallback用）
     """
-    s = (album or "").lower().strip()
+    s = _normalize_dash_chars((album or "").lower().strip())
     s = re.sub(r"\([^)]*\)", "", s)
     s = re.sub(r"\[[^]]*\]", "", s)
     s = re.sub(r"\s+", " ", s).strip()
@@ -100,6 +114,19 @@ def generate_title_artist_pairs(title: str, artist: str) -> List[Tuple[str, str]
 
     if base_title_norm and base_artist_norm:
         pairs.append((base_title_norm, base_artist_norm))
+
+    if not base_artist_norm:
+        title_tokens = [tok for tok in base_title_norm.split() if tok]
+        if 2 <= len(title_tokens) <= 6:
+            for split_idx in range(1, len(title_tokens)):
+                left_raw = " ".join(title_tokens[:split_idx])
+                right_raw = " ".join(title_tokens[split_idx:])
+                cand_artist_norm = normalize_artist(left_raw)
+                cand_title_norm = normalize_title_base(right_raw)
+                if cand_artist_norm and cand_title_norm:
+                    key = (cand_title_norm, cand_artist_norm)
+                    if key not in pairs:
+                        pairs.append(key)
 
     # "X - Y" パターンを追加候補として扱う
     m = re.match(r"^(?P<left>.+?)\s*-\s*(?P<right>.+)$", title.strip())

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -12,6 +12,13 @@ def _write_xml(tmp_path: Path) -> Path:
     <TRACK Name="Bright Lights" Artist="Artist B" Album="Album B" />
     <TRACK Name="Goodums_-_Sammy_Virji_Remix" Artist="Sammy Virji" Album="Album C" />
     <TRACK Name="Shapes_(Oh_Will)_-_Oppidan_Remix" Artist="Oppidan" Album="Album D" />
+    <TRACK Name="WHO 160-145" Artist="Port London" Album="WHO" />
+    <TRACK Name="Takumi Maki Civic Master" Artist="" Album="" />
+    <TRACK Name="CORRUPT us - Posij &amp; ZEP Remix 169.98" Artist="ZEP, Posij" Album="CORRUPT us (Posij &amp; ZEP Remix)" />
+    <TRACK Name="Outer Space (JAMPAGNE Remix)" Artist="Habstrakt, Roderick Porter, JAMPAGNE" Album="Heritage - Remixes" />
+    <TRACK Name="Before Love (Extended)" Artist="The Good Son" Album="Before Love" />
+    <TRACK Name="Somewhere Near Marseilles (Sci-Fi Edit)" Artist="Hikaru Utada" Album="SCIENCE FICTION" />
+    <TRACK Name="Thierry Henry (Modeā Extended Remix)" Artist="Ev, Modeā" Album="Thierry Henry (Modeā Extended Remix)" />
   </COLLECTION>
 </DJ_PLAYLISTS>
 """
@@ -85,6 +92,87 @@ class MatcherTests(unittest.TestCase):
         self.assertEqual(result["tracks"][0]["owned_reason"], "exact")
         self.assertTrue(result["tracks"][1]["owned"])
         self.assertEqual(result["tracks"][1]["owned_reason"], "exact")
+
+    def test_mark_owned_matches_known_false_negative_variants(self):
+        tmp_dir = Path(self._get_tmp_dir())
+        xml_path = _write_xml(tmp_dir)
+        playlist = {
+            "tracks": [
+                {
+                    "title": "WHO",
+                    "artist": "Port London",
+                    "album": "WHO",
+                    "isrc": None,
+                },
+                {
+                    "title": "Civic",
+                    "artist": "Takumi Maki",
+                    "album": "Civic",
+                    "isrc": None,
+                },
+                {
+                    "title": "CORRUPT us - Posij & ZEP Remix",
+                    "artist": "ZEP, Posij",
+                    "album": "CORRUPT us (Posij & ZEP Remix)",
+                    "isrc": None,
+                },
+                {
+                    "title": "Outer Space - JAMPAGNE Remix",
+                    "artist": "Habstrakt, Roderick Porter, JAMPAGNE",
+                    "album": "Heritage (Remixes)",
+                    "isrc": None,
+                },
+                {
+                    "title": "Before Love - Extended",
+                    "artist": "The Good Son",
+                    "album": "Before Love",
+                    "isrc": None,
+                },
+                {
+                    "title": "Somewhere Near Marseilles — マルセイユ辺りー",
+                    "artist": "Hikaru Utada",
+                    "album": "BADモード",
+                    "isrc": None,
+                },
+                {
+                    "title": "Thierry Henry - Modeā Remix",
+                    "artist": "EV, Modeā",
+                    "album": "Sunrise Behind The Tower Blocks",
+                    "isrc": None,
+                },
+            ]
+        }
+
+        result = mark_owned_tracks(playlist, xml_path)
+
+        expected_owned = {
+            "WHO",
+            "Civic",
+            "CORRUPT us - Posij & ZEP Remix",
+            "Outer Space - JAMPAGNE Remix",
+            "Before Love - Extended",
+            "Thierry Henry - Modeā Remix",
+        }
+
+        for track in result["tracks"]:
+            if track["title"] == "Somewhere Near Marseilles — マルセイユ辺りー":
+                self.assertFalse(
+                    track["owned"],
+                    msg="Localized Marseilles title should not match the Sci-Fi Edit",
+                )
+                self.assertIsNone(track["owned_reason"])
+                continue
+
+            self.assertIn(track["title"], expected_owned)
+            self.assertTrue(
+                track["owned"],
+                msg=f"Expected owned match for {track['artist']} - {track['title']}",
+            )
+            self.assertIn(
+                track["owned_reason"],
+                {"exact", "album", "fuzzy"},
+                msg=f"Unexpected ownership reason for {track['artist']} - {track['title']}",
+            )
 
     def _get_tmp_dir(self) -> str:
         # unittest doesn't provide tmp_path fixture; use mkdtemp

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -3,6 +3,7 @@ from lib.rekordbox.normalizer import (
     normalize_artist,
     normalize_title_base,
     normalize_album,
+    generate_title_artist_pairs,
 )
 
 
@@ -16,12 +17,33 @@ class NormalizeTests(unittest.TestCase):
         self.assertEqual(normalize_title_base("Track [Deluxe] - Radio Edit"), "track")
         self.assertEqual(
             normalize_title_base("Goodums_-_Sammy_Virji_Remix"),
-            "goodums - sammy virji remix",
+            "goodums",
         )
         self.assertEqual(
             normalize_title_base("Shapes_(Oh_Will)_-_Oppidan_Remix"),
-            "shapes - oppidan remix",
+            "shapes",
         )
+        self.assertEqual(normalize_title_base("WHO 160-145"), "who")
+        self.assertEqual(
+            normalize_title_base("CORRUPT us - Posij & ZEP Remix 169.98"),
+            "corrupt us",
+        )
+        self.assertEqual(
+            normalize_title_base("Before Love - Extended"),
+            "before love",
+        )
+        self.assertEqual(
+            normalize_title_base("Takumi Maki Civic Master"),
+            "takumi maki civic",
+        )
+        self.assertEqual(
+            normalize_title_base("Somewhere Near Marseilles — マルセイユ辺りー"),
+            "somewhere near marseilles - マルセイユ辺りー",
+        )
+
+    def test_generate_title_artist_pairs_derives_artist_when_artist_field_empty(self):
+        pairs = generate_title_artist_pairs("Takumi Maki Civic Master", "")
+        self.assertIn(("civic", "takumi maki"), pairs)
 
     def test_normalize_album_simplifies_spacing(self):
         self.assertEqual(normalize_album("Album Name (Deluxe Edition)"), "album name")


### PR DESCRIPTION
Closes #21.

Improves conservative Rekordbox ownership matching for known false-negative variants.

Changes:
- Add matcher fixtures for known false-negative cases
- Improve title/artist normalization conservatively
- Handle trailing tempo/BPM suffixes
- Handle trailing Master suffix
- Derive artist/title pairs when Rekordbox artist field is empty
- Preserve Marseilles localized/Sci-Fi Edit distinction as not owned
- Avoid broad fuzzy threshold changes

Validation:
- python -m unittest tests.test_matcher tests.test_normalizer tests.test_upload_contract tests.test_health -v
- python -m unittest discover -s tests -p "test_*.py" -v
- git diff --check