### PR TITLE
Add golden Rekordbox ownership fixture

### DIFF
--- a/tests/fixtures/rekordbox/golden_expected.json
+++ b/tests/fixtures/rekordbox/golden_expected.json
@@ -1,0 +1,56 @@
+[
+  {
+    "title": "Bright Lights",
+    "artist": "Artist B",
+    "owned": true,
+    "owned_reason": "exact"
+  },
+  {
+    "title": "Goodums - Sammy Virji Remix",
+    "artist": "Sammy Virji",
+    "owned": true,
+    "owned_reason": "exact"
+  },
+  {
+    "title": "WHO",
+    "artist": "Port London",
+    "owned": true,
+    "owned_reason": "exact"
+  },
+  {
+    "title": "Civic",
+    "artist": "Takumi Maki",
+    "owned": true,
+    "owned_reason": "exact"
+  },
+  {
+    "title": "CORRUPT us - Posij & ZEP Remix",
+    "artist": "ZEP, Posij",
+    "owned": true,
+    "owned_reason": "exact"
+  },
+  {
+    "title": "Outer Space - JAMPAGNE Remix",
+    "artist": "Habstrakt, Roderick Porter, JAMPAGNE",
+    "owned": true,
+    "owned_reason": "exact"
+  },
+  {
+    "title": "Before Love - Extended",
+    "artist": "The Good Son",
+    "owned": true,
+    "owned_reason": "exact"
+  },
+  {
+    "title": "Thierry Henry - Modeā Remix",
+    "artist": "EV, Modeā",
+    "owned": true,
+    "owned_reason": "exact"
+  },
+  {
+    "title": "Somewhere Near Marseilles — マルセイユ辺りー",
+    "artist": "Hikaru Utada",
+    "owned": false,
+    "owned_reason": null
+  }
+]

--- a/tests/fixtures/rekordbox/golden_library.xml
+++ b/tests/fixtures/rekordbox/golden_library.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DJ_PLAYLISTS Version="1.0.0">
+  <COLLECTION Entries="9">
+    <TRACK TrackID="1" Name="Bright Lights" Artist="Artist B" Album="Album B" />
+    <TRACK TrackID="2" Name="Goodums_-_Sammy_Virji_Remix" Artist="Sammy Virji" Album="Goodums" />
+    <TRACK TrackID="3" Name="WHO 160-145" Artist="Port London" Album="WHO" />
+    <TRACK TrackID="4" Name="Takumi Maki Civic Master" Artist="" Album="" />
+    <TRACK TrackID="5" Name="CORRUPT us - Posij &amp; ZEP Remix 169.98" Artist="ZEP, Posij" Album="CORRUPT us (Posij &amp; ZEP Remix)" />
+    <TRACK TrackID="6" Name="Outer Space (JAMPAGNE Remix)" Artist="Habstrakt, Roderick Porter, JAMPAGNE" Album="Heritage - Remixes" />
+    <TRACK TrackID="7" Name="Before Love (Extended)" Artist="The Good Son" Album="Before Love" />
+    <TRACK TrackID="8" Name="Thierry Henry (Modeā Extended Remix)" Artist="Ev, Modeā" Album="Thierry Henry (Modeā Extended Remix)" />
+    <TRACK TrackID="9" Name="Somewhere Near Marseilles (Sci-Fi Edit)" Artist="Hikaru Utada" Album="SCIENCE FICTION" />
+  </COLLECTION>
+</DJ_PLAYLISTS>

--- a/tests/fixtures/rekordbox/golden_playlist.json
+++ b/tests/fixtures/rekordbox/golden_playlist.json
@@ -1,0 +1,58 @@
+{
+  "tracks": [
+    {
+      "title": "Bright Lights",
+      "artist": "Artist B",
+      "album": "Album B",
+      "isrc": null
+    },
+    {
+      "title": "Goodums - Sammy Virji Remix",
+      "artist": "Sammy Virji",
+      "album": "Goodums",
+      "isrc": null
+    },
+    {
+      "title": "WHO",
+      "artist": "Port London",
+      "album": "WHO",
+      "isrc": null
+    },
+    {
+      "title": "Civic",
+      "artist": "Takumi Maki",
+      "album": "Civic",
+      "isrc": null
+    },
+    {
+      "title": "CORRUPT us - Posij & ZEP Remix",
+      "artist": "ZEP, Posij",
+      "album": "CORRUPT us (Posij & ZEP Remix)",
+      "isrc": null
+    },
+    {
+      "title": "Outer Space - JAMPAGNE Remix",
+      "artist": "Habstrakt, Roderick Porter, JAMPAGNE",
+      "album": "Heritage (Remixes)",
+      "isrc": null
+    },
+    {
+      "title": "Before Love - Extended",
+      "artist": "The Good Son",
+      "album": "Before Love",
+      "isrc": null
+    },
+    {
+      "title": "Thierry Henry - Modeā Remix",
+      "artist": "EV, Modeā",
+      "album": "Sunrise Behind The Tower Blocks",
+      "isrc": null
+    },
+    {
+      "title": "Somewhere Near Marseilles — マルセイユ辺りー",
+      "artist": "Hikaru Utada",
+      "album": "BADモード",
+      "isrc": null
+    }
+  ]
+}

--- a/tests/test_golden_ownership.py
+++ b/tests/test_golden_ownership.py
@@ -1,0 +1,44 @@
+import json
+import unittest
+from pathlib import Path
+
+from lib.rekordbox.matcher import mark_owned_tracks
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "rekordbox"
+
+
+class GoldenOwnershipTests(unittest.TestCase):
+    def test_golden_rekordbox_ownership(self):
+        with (FIXTURE_DIR / "golden_playlist.json").open(encoding="utf-8") as file:
+            playlist = json.load(file)
+        with (FIXTURE_DIR / "golden_expected.json").open(encoding="utf-8") as file:
+            expected = json.load(file)
+
+        result = mark_owned_tracks(
+            playlist,
+            FIXTURE_DIR / "golden_library.xml",
+        )
+        compact_result = [
+            {
+                "title": track["title"],
+                "artist": track["artist"],
+                "owned": track["owned"],
+                "owned_reason": track.get("owned_reason"),
+            }
+            for track in result["tracks"]
+        ]
+
+        self.assertEqual(compact_result, expected)
+
+        marseilles = next(
+            track
+            for track in compact_result
+            if track["title"] == "Somewhere Near Marseilles — マルセイユ辺りー"
+        )
+        self.assertFalse(marseilles["owned"])
+        self.assertIsNone(marseilles.get("owned_reason"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a small golden Rekordbox fixture to protect core Owned / To buy matching behavior.

Changes:
- Add synthetic Rekordbox XML fixture
- Add golden playlist and expected ownership fixture
- Add golden ownership regression test
- Protect known owned variants
- Protect Marseilles localized/Sci-Fi Edit distinction as not owned

Validation:
- python -m unittest tests.test_golden_ownership -v
- python -m unittest tests.test_matcher tests.test_normalizer tests.test_upload_contract tests.test_health -v
- python -m unittest discover -s tests -p "test_*.py" -v
- git diff --check