### PR TITLE
Add HEAD health route for uptime checks

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,6 +95,7 @@ from fastapi import (
     FastAPI,
     HTTPException,
     Query,
+    Response,
     UploadFile,
     File,
     Form,
@@ -362,6 +363,11 @@ def root() -> Dict[str, Any]:
 @app.get("/health", include_in_schema=False)
 def render_health() -> Dict[str, Any]:
     return health()
+
+
+@app.head("/health", include_in_schema=False)
+def render_health_head() -> Response:
+    return Response(status_code=200)
 
 
 # =========================

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -17,6 +17,11 @@ class HealthRouteTests(unittest.TestCase):
         self.assertIs(payload["ok"], True)
         self.assertEqual(payload["status"], "ok")
 
+    def test_render_health_head_route_returns_ok(self):
+        response = client.head("/health")
+
+        self.assertEqual(response.status_code, 200)
+
     def test_api_health_route_still_returns_ok(self):
         response = client.get("/api/health")
 


### PR DESCRIPTION
Allows uptime monitors that use HEAD requests to check /health without receiving 405.

Changes:
- Add HEAD /health route returning 200
- Keep existing GET /health response unchanged
- Add or update health route tests if applicable

Validation:
- python -m unittest discover -s tests -p "test_*.py" -v
- git diff --check